### PR TITLE
use an external verifier for Risc0 STARK proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,4 @@ Below are the primary files in the project directory
 [risc0/risc0]: https://github.com/risc0/risc0/tree/main/bonsai/ethereum-relay
 [zkVM guest program]: https://www.dev.risczero.com/terminology#guest-program
 [zkVM]: https://www.dev.risczero.com/terminology#zero-knowledge-virtual-machine-zkvm
+ 


### PR DESCRIPTION
## request for updated version
This is a really neat application!

Hoping to get developers like yourself to deploy demo apps like zksnake on one of the EVM's we have linked zkVerify to. 

Can you modify this to use a Risc0 STARK verifier, using the instructions here? https://docs.zkverify.io/tutorials/tutorials and here: https://docs.zkverify.io/tutorials/submit-proofs/risc0_proof_submission

It would make the proof generation faster, able to work on devices with ARM processor, and although it requires modification to deploy and use on an EVM, overall could be useful. We checked the Risc0 benchmarks, and not wrapping the proof in groth16 saves about 15 seconds per proof.

Also have a grants program, and an incentivized testnet for our upcoming token launch.

If interested, you can reach me by Telegram @blockops or email by rolf@horizenlabs.io - thank you!